### PR TITLE
Access apprenticeship model from integration test

### DIFF
--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/LearnerWithRealisticHistory.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/LearnerWithRealisticHistory.cs
@@ -18,6 +18,7 @@ using PaymentsApprenticeshipStatus = SFA.DAS.Payments.Model.Core.Entities.Appren
 
 namespace SFA.DAS.LearnerDataMismatches.IntegrationTests
 {
+    [Explicit]
     public class LearnerWithRealisticHistory
     {
         [SetUp]

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/LearnerWithRealisticHistory.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/LearnerWithRealisticHistory.cs
@@ -6,6 +6,7 @@ using NUnit.Framework.Internal;
 using SFA.DAS.Apprenticeships.Api.Types.Providers;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Responses;
+using SFA.DAS.EAS.Account.Api.Types;
 using SFA.DAS.LearnerDataMismatches.Domain;
 using SFA.DAS.LearnerDataMismatches.Web.Pages;
 using SFA.DAS.Payments.Model.Core.Audit;
@@ -158,6 +159,25 @@ namespace SFA.DAS.LearnerDataMismatches.IntegrationTests
 
             learner.ProviderId.Should().Be(apprenticeship.Ukprn.ToString());
             learner.ProviderName.Should().Be("Best Training Provider");
+        }
+
+        [Test]
+        public async Task Account_details_are_shown()
+        {
+            Testing.AccountsApi
+                .GetAccount(apprenticeship.AccountId)
+                .Returns(Task.FromResult(new AccountDetailViewModel
+                {
+                    DasAccountName = "Fantastic Employer",
+                    PublicHashedAccountId = "qwerty",
+                }));
+
+            var learner = Testing.CreatePage<LearnerModel>();
+            learner.Uln = apprenticeship.Uln.ToString();
+            await learner.OnGetAsync();
+
+            learner.EmployerId.Should().Be("qwerty");
+            learner.EmployerName.Should().Be("Fantastic Employer");
         }
 
         [Test]

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
@@ -20,5 +20,17 @@ namespace SFA.DAS.LearnerDataMismatches.IntegrationTests
             services.RemoveAll(typeof(T));
             services.AddScoped(service);
         }
+
+        public static void ConfigureMockServices<T1, T2>(
+            this ServiceCollection services,
+            Func<IServiceProvider, T1> service1,
+            Func<IServiceProvider, T2> service2
+            )
+            where T1 : class where T2 : class
+        {
+            services.ConfigureMockService(service1);
+            services.ConfigureMockService(service2);
+        }
+
     }
 }

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
@@ -12,35 +12,14 @@ namespace SFA.DAS.LearnerDataMismatches.IntegrationTests
             services.AddScoped<LearnerModel>();
         }
 
-        public static void ConfigureMockService<T>(
+        public static ServiceCollection ConfigureMockService<T>(
             this ServiceCollection services,
             Func<IServiceProvider, T> service)
             where T : class
         {
             services.RemoveAll(typeof(T));
             services.AddScoped(service);
-        }
-
-        public static void ConfigureMockServices<T1, T2>(
-            this ServiceCollection services,
-            Func<IServiceProvider, T1> service1,
-            Func<IServiceProvider, T2> service2)
-            where T1 : class where T2 : class
-        {
-            services.ConfigureMockService(service1);
-            services.ConfigureMockService(service2);
-        }
-
-        public static void ConfigureMockServices<T1, T2, T3>(
-            this ServiceCollection services,
-            Func<IServiceProvider, T1> service1,
-            Func<IServiceProvider, T2> service2,
-            Func<IServiceProvider, T3> service3)
-            where T1 : class where T2 : class where T3 : class
-        {
-            services.ConfigureMockService(service1);
-            services.ConfigureMockService(service2);
-            services.ConfigureMockService(service3);
+            return services;
         }
     }
 }

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/TestConfigurationExtensions.cs
@@ -24,13 +24,23 @@ namespace SFA.DAS.LearnerDataMismatches.IntegrationTests
         public static void ConfigureMockServices<T1, T2>(
             this ServiceCollection services,
             Func<IServiceProvider, T1> service1,
-            Func<IServiceProvider, T2> service2
-            )
+            Func<IServiceProvider, T2> service2)
             where T1 : class where T2 : class
         {
             services.ConfigureMockService(service1);
             services.ConfigureMockService(service2);
         }
 
+        public static void ConfigureMockServices<T1, T2, T3>(
+            this ServiceCollection services,
+            Func<IServiceProvider, T1> service1,
+            Func<IServiceProvider, T2> service2,
+            Func<IServiceProvider, T3> service3)
+            where T1 : class where T2 : class where T3 : class
+        {
+            services.ConfigureMockService(service1);
+            services.ConfigureMockService(service2);
+            services.ConfigureMockService(service3);
+        }
     }
 }

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Respawn;
 using SFA.DAS.CommitmentsV2.Api.Client;
+using SFA.DAS.EAS.Account.Api.Client;
 using SFA.DAS.LearnerDataMismatches.IntegrationTests;
 using SFA.DAS.LearnerDataMismatches.Web;
 using SFA.DAS.Payments.Application.Repositories;
@@ -30,6 +31,7 @@ public static class Testing
 
     public static ICommitmentsApiClient CommitmentsApi;
     public static IProviderApiClient ProviderApi;
+    public static IAccountApiClient AccountsApi;
 
     [OneTimeSetUp]
     public static void RunBeforeAnyTests()
@@ -54,7 +56,10 @@ public static class Testing
         new Startup(configuration).ConfigureServices(services);
         services.AddLogging();
         services.AddPages();
-        services.ConfigureMockServices(_ => CommitmentsApi, _ => ProviderApi);
+        services.ConfigureMockServices(
+            _ => CommitmentsApi,
+            _ => ProviderApi,
+            _ => AccountsApi);
         return services;
     }
 
@@ -105,5 +110,6 @@ public static class Testing
         await checkpoint.Reset(configuration.GetConnectionString("PaymentsDatabase"));
         CommitmentsApi = Substitute.For<ICommitmentsApiClient>();
         ProviderApi = Substitute.For<IProviderApiClient>();
+        AccountsApi = Substitute.For<IAccountApiClient>();
     }
 }

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
@@ -56,10 +56,10 @@ public static class Testing
         new Startup(configuration).ConfigureServices(services);
         services.AddLogging();
         services.AddPages();
-        services.ConfigureMockServices(
-            _ => CommitmentsApi,
-            _ => ProviderApi,
-            _ => AccountsApi);
+        services
+            .ConfigureMockService(_ => CommitmentsApi)
+            .ConfigureMockService(_ => ProviderApi)
+            .ConfigureMockService(_ => AccountsApi);
         return services;
     }
 

--- a/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
+++ b/src/SFA.DAS.LearnerDataMismatches.IntegrationTests/Testing.cs
@@ -9,6 +9,7 @@ using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.LearnerDataMismatches.IntegrationTests;
 using SFA.DAS.LearnerDataMismatches.Web;
 using SFA.DAS.Payments.Application.Repositories;
+using SFA.DAS.Providers.Api.Client;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -28,6 +29,7 @@ public static class Testing
     private static Checkpoint checkpoint;
 
     public static ICommitmentsApiClient CommitmentsApi;
+    public static IProviderApiClient ProviderApi;
 
     [OneTimeSetUp]
     public static void RunBeforeAnyTests()
@@ -52,7 +54,7 @@ public static class Testing
         new Startup(configuration).ConfigureServices(services);
         services.AddLogging();
         services.AddPages();
-        services.ConfigureMockService(_ => CommitmentsApi);
+        services.ConfigureMockServices(_ => CommitmentsApi, _ => ProviderApi);
         return services;
     }
 
@@ -102,5 +104,6 @@ public static class Testing
     {
         await checkpoint.Reset(configuration.GetConnectionString("PaymentsDatabase"));
         CommitmentsApi = Substitute.For<ICommitmentsApiClient>();
+        ProviderApi = Substitute.For<IProviderApiClient>();
     }
 }


### PR DESCRIPTION
New tests for Provider and Account names.

Expose the apprentice model to the integration test so that the test can use its Account ID / UKPRN, rather than separately hard-coding those values in the test itself.